### PR TITLE
Use same clang-format rules as node, reformat code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,111 @@
-BasedOnStyle: Google
-SortIncludes: Never
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:      80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never

--- a/include/ncrypto.h
+++ b/include/ncrypto.h
@@ -61,14 +61,14 @@ namespace ncrypto {
 
 #if NCRYPTO_DEVELOPMENT_CHECKS
 #define NCRYPTO_STR(x) #x
-#define NCRYPTO_REQUIRE(EXPR) \
-  {                           \
+#define NCRYPTO_REQUIRE(EXPR)                                                  \
+  {                                                                            \
     if (!(EXPR) { abort(); }) }
 
-#define NCRYPTO_FAIL(MESSAGE)                        \
-  do {                                               \
-    std::cerr << "FAIL: " << (MESSAGE) << std::endl; \
-    abort();                                         \
+#define NCRYPTO_FAIL(MESSAGE)                                                  \
+  do {                                                                         \
+    std::cerr << "FAIL: " << (MESSAGE) << std::endl;                           \
+    abort();                                                                   \
   } while (0);
 #define NCRYPTO_ASSERT_EQUAL(LHS, RHS, MESSAGE)                                \
   do {                                                                         \
@@ -77,13 +77,13 @@ namespace ncrypto {
       NCRYPTO_FAIL(MESSAGE);                                                   \
     }                                                                          \
   } while (0);
-#define NCRYPTO_ASSERT_TRUE(COND)                                           \
-  do {                                                                      \
-    if (!(COND)) {                                                          \
-      std::cerr << "Assert at line " << __LINE__ << " of file " << __FILE__ \
-                << std::endl;                                               \
-      NCRYPTO_FAIL(NCRYPTO_STR(COND));                                      \
-    }                                                                       \
+#define NCRYPTO_ASSERT_TRUE(COND)                                              \
+  do {                                                                         \
+    if (!(COND)) {                                                             \
+      std::cerr << "Assert at line " << __LINE__ << " of file " << __FILE__    \
+                << std::endl;                                                  \
+      NCRYPTO_FAIL(NCRYPTO_STR(COND));                                         \
+    }                                                                          \
   } while (0);
 #else
 #define NCRYPTO_FAIL(MESSAGE)
@@ -91,17 +91,17 @@ namespace ncrypto {
 #define NCRYPTO_ASSERT_TRUE(COND)
 #endif
 
-#define NCRYPTO_DISALLOW_COPY(Name) \
-  Name(const Name&) = delete;       \
+#define NCRYPTO_DISALLOW_COPY(Name)                                            \
+  Name(const Name&) = delete;                                                  \
   Name& operator=(const Name&) = delete;
-#define NCRYPTO_DISALLOW_MOVE(Name) \
-  Name(Name&&) = delete;            \
+#define NCRYPTO_DISALLOW_MOVE(Name)                                            \
+  Name(Name&&) = delete;                                                       \
   Name& operator=(Name&&) = delete;
-#define NCRYPTO_DISALLOW_COPY_AND_MOVE(Name) \
-  NCRYPTO_DISALLOW_COPY(Name)                \
+#define NCRYPTO_DISALLOW_COPY_AND_MOVE(Name)                                   \
+  NCRYPTO_DISALLOW_COPY(Name)                                                  \
   NCRYPTO_DISALLOW_MOVE(Name)
-#define NCRYPTO_DISALLOW_NEW_DELETE()  \
-  void* operator new(size_t) = delete; \
+#define NCRYPTO_DISALLOW_NEW_DELETE()                                          \
+  void* operator new(size_t) = delete;                                         \
   void operator delete(void*) = delete;
 
 [[noreturn]] inline void unreachable() {
@@ -299,7 +299,8 @@ class Cipher final {
                              const CipherParams& params,
                              const Buffer<const void> in);
 
-  static DataPointer sign(const EVPKeyPointer& key, const CipherParams& params,
+  static DataPointer sign(const EVPKeyPointer& key,
+                          const CipherParams& params,
                           const Buffer<const void> in);
 
   static DataPointer recover(const EVPKeyPointer& key,
@@ -392,7 +393,8 @@ class BignumPointer final {
 
   static DataPointer Encode(const BIGNUM* bn);
   static DataPointer EncodePadded(const BIGNUM* bn, size_t size);
-  static size_t EncodePaddedInto(const BIGNUM* bn, unsigned char* out,
+  static size_t EncodePaddedInto(const BIGNUM* bn,
+                                 unsigned char* out,
                                  size_t size);
   static int GetBitCount(const BIGNUM* bn);
   static int GetByteCount(const BIGNUM* bn);
@@ -439,8 +441,11 @@ class Rsa final {
   const std::optional<PssParams> getPssParams() const;
 
   bool setPublicKey(BignumPointer&& n, BignumPointer&& e);
-  bool setPrivateKey(BignumPointer&& d, BignumPointer&& q, BignumPointer&& p,
-                     BignumPointer&& dp, BignumPointer&& dq,
+  bool setPrivateKey(BignumPointer&& d,
+                     BignumPointer&& q,
+                     BignumPointer&& p,
+                     BignumPointer&& dp,
+                     BignumPointer&& dq,
                      BignumPointer&& qi);
 
   using CipherParams = Cipher::CipherParams;
@@ -613,7 +618,8 @@ class CipherCtxPointer final {
   bool setAeadTag(const Buffer<const char>& tag);
   bool setAeadTagLength(size_t length);
   bool setPadding(bool padding);
-  bool init(const Cipher& cipher, bool encrypt,
+  bool init(const Cipher& cipher,
+            bool encrypt,
             const unsigned char* key = nullptr,
             const unsigned char* iv = nullptr);
 
@@ -621,8 +627,10 @@ class CipherCtxPointer final {
   int getMode() const;
   int getNid() const;
 
-  bool update(const Buffer<const unsigned char>& in, unsigned char* out,
-              int* out_len, bool finalize = false);
+  bool update(const Buffer<const unsigned char>& in,
+              unsigned char* out,
+              int* out_len,
+              bool finalize = false);
   bool getAeadTag(size_t len, unsigned char* out);
 
  private:
@@ -678,7 +686,8 @@ class EVPKeyCtxPointer final {
 
   static constexpr int kDefaultRsaExponent = 0x10001;
 
-  static bool setRsaPadding(EVP_PKEY_CTX* ctx, int padding,
+  static bool setRsaPadding(EVP_PKEY_CTX* ctx,
+                            int padding,
                             std::optional<int> salt_len = std::nullopt);
 
   EVPKeyPointer paramgen() const;
@@ -731,7 +740,8 @@ class EVPKeyPointer final {
     PKFormatType format = PKFormatType::DER;
     PKEncodingType type = PKEncodingType::PKCS8;
     AsymmetricKeyEncodingConfig() = default;
-    AsymmetricKeyEncodingConfig(bool output_key_object, PKFormatType format,
+    AsymmetricKeyEncodingConfig(bool output_key_object,
+                                PKFormatType format,
                                 PKEncodingType type);
     AsymmetricKeyEncodingConfig(const AsymmetricKeyEncodingConfig&) = default;
     AsymmetricKeyEncodingConfig& operator=(const AsymmetricKeyEncodingConfig&) =
@@ -743,7 +753,8 @@ class EVPKeyPointer final {
     const EVP_CIPHER* cipher = nullptr;
     std::optional<DataPointer> passphrase = std::nullopt;
     PrivateKeyEncodingConfig() = default;
-    PrivateKeyEncodingConfig(bool output_key_object, PKFormatType format,
+    PrivateKeyEncodingConfig(bool output_key_object,
+                             PKFormatType format,
                              PKEncodingType type)
         : AsymmetricKeyEncodingConfig(output_key_object, format, type) {}
     PrivateKeyEncodingConfig(const PrivateKeyEncodingConfig&);
@@ -1072,7 +1083,8 @@ class X509View final {
     INVALID_NAME,
     OPERATION_FAILED,
   };
-  CheckMatch checkHost(const std::string_view host, int flags,
+  CheckMatch checkHost(const std::string_view host,
+                       int flags,
                        DataPointer* peerName = nullptr) const;
   CheckMatch checkEmail(const std::string_view email, int flags) const;
   CheckMatch checkIp(const std::string_view ip, int flags) const;
@@ -1404,35 +1416,53 @@ const EVP_CIPHER* getCipherByName(const std::string_view name);
 // hash size for the given digest algorithm.
 bool checkHkdfLength(const EVP_MD* md, size_t length);
 
-bool extractP1363(const Buffer<const unsigned char>& buf, unsigned char* dest,
+bool extractP1363(const Buffer<const unsigned char>& buf,
+                  unsigned char* dest,
                   size_t n);
 
-bool hkdfInfo(const EVP_MD* md, const Buffer<const unsigned char>& key,
+bool hkdfInfo(const EVP_MD* md,
+              const Buffer<const unsigned char>& key,
               const Buffer<const unsigned char>& info,
-              const Buffer<const unsigned char>& salt, size_t length,
+              const Buffer<const unsigned char>& salt,
+              size_t length,
               Buffer<unsigned char>* out);
 
-DataPointer hkdf(const EVP_MD* md, const Buffer<const unsigned char>& key,
+DataPointer hkdf(const EVP_MD* md,
+                 const Buffer<const unsigned char>& key,
                  const Buffer<const unsigned char>& info,
-                 const Buffer<const unsigned char>& salt, size_t length);
+                 const Buffer<const unsigned char>& salt,
+                 size_t length);
 
 bool checkScryptParams(uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem);
 
 bool scryptInto(const Buffer<const char>& pass,
-                const Buffer<const unsigned char>& salt, uint64_t N, uint64_t r,
-                uint64_t p, uint64_t maxmem, size_t length,
+                const Buffer<const unsigned char>& salt,
+                uint64_t N,
+                uint64_t r,
+                uint64_t p,
+                uint64_t maxmem,
+                size_t length,
                 Buffer<unsigned char>* out);
 
 DataPointer scrypt(const Buffer<const char>& pass,
-                   const Buffer<const unsigned char>& salt, uint64_t N,
-                   uint64_t r, uint64_t p, uint64_t maxmem, size_t length);
+                   const Buffer<const unsigned char>& salt,
+                   uint64_t N,
+                   uint64_t r,
+                   uint64_t p,
+                   uint64_t maxmem,
+                   size_t length);
 
-bool pbkdf2Into(const EVP_MD* md, const Buffer<const char>& pass,
-                const Buffer<const unsigned char>& salt, uint32_t iterations,
-                size_t length, Buffer<unsigned char>* out);
+bool pbkdf2Into(const EVP_MD* md,
+                const Buffer<const char>& pass,
+                const Buffer<const unsigned char>& salt,
+                uint32_t iterations,
+                size_t length,
+                Buffer<unsigned char>* out);
 
-DataPointer pbkdf2(const EVP_MD* md, const Buffer<const char>& pass,
-                   const Buffer<const unsigned char>& salt, uint32_t iterations,
+DataPointer pbkdf2(const EVP_MD* md,
+                   const Buffer<const char>& pass,
+                   const Buffer<const unsigned char>& salt,
+                   uint32_t iterations,
                    size_t length);
 
 // ============================================================================

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -14,7 +14,9 @@ EnginePointer::EnginePointer(EnginePointer&& other) noexcept
   other.release();
 }
 
-EnginePointer::~EnginePointer() { reset(); }
+EnginePointer::~EnginePointer() {
+  reset();
+}
 
 EnginePointer& EnginePointer::operator=(EnginePointer&& other) noexcept {
   if (this == &other) return *this;

--- a/src/ncrypto.cpp
+++ b/src/ncrypto.cpp
@@ -23,9 +23,13 @@
 
 // EVP_PKEY_CTX_set_dsa_paramgen_q_bits was added in OpenSSL 1.1.1e.
 #if OPENSSL_VERSION_NUMBER < 0x1010105fL
-#define EVP_PKEY_CTX_set_dsa_paramgen_q_bits(ctx, qbits)       \
-  EVP_PKEY_CTX_ctrl((ctx), EVP_PKEY_DSA, EVP_PKEY_OP_PARAMGEN, \
-                    EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS, (qbits), nullptr)
+#define EVP_PKEY_CTX_set_dsa_paramgen_q_bits(ctx, qbits)                       \
+  EVP_PKEY_CTX_ctrl((ctx),                                                     \
+                    EVP_PKEY_DSA,                                              \
+                    EVP_PKEY_OP_PARAMGEN,                                      \
+                    EVP_PKEY_CTRL_DSA_PARAMGEN_Q_BITS,                         \
+                    (qbits),                                                   \
+                    nullptr)
 #endif
 
 // ============================================================================
@@ -52,7 +56,9 @@ ClearErrorOnReturn::~ClearErrorOnReturn() {
   ERR_clear_error();
 }
 
-int ClearErrorOnReturn::peekError() { return ERR_peek_error(); }
+int ClearErrorOnReturn::peekError() {
+  return ERR_peek_error();
+}
 
 MarkPopErrorOnReturn::MarkPopErrorOnReturn(CryptoErrorList* errors)
     : errors_(errors) {
@@ -64,7 +70,9 @@ MarkPopErrorOnReturn::~MarkPopErrorOnReturn() {
   ERR_pop_to_mark();
 }
 
-int MarkPopErrorOnReturn::peekError() { return ERR_peek_error(); }
+int MarkPopErrorOnReturn::peekError() {
+  return ERR_peek_error();
+}
 
 CryptoErrorList::CryptoErrorList(CryptoErrorList::Option option) {
   if (option == Option::CAPTURE_ON_CONSTRUCT) capture();
@@ -79,7 +87,9 @@ void CryptoErrorList::capture() {
   }
 }
 
-void CryptoErrorList::add(std::string error) { errors_.push_back(error); }
+void CryptoErrorList::add(std::string error) {
+  errors_.push_back(error);
+}
 
 std::optional<std::string> CryptoErrorList::pop_back() {
   if (errors_.empty()) return std::nullopt;
@@ -130,7 +140,9 @@ DataPointer& DataPointer::operator=(DataPointer&& other) noexcept {
   return *new (this) DataPointer(std::move(other));
 }
 
-DataPointer::~DataPointer() { reset(); }
+DataPointer::~DataPointer() {
+  reset();
+}
 
 void DataPointer::zero() {
   if (!data_) return;
@@ -217,7 +229,9 @@ BignumPointer::BignumPointer(const unsigned char* data, size_t len)
 BignumPointer::BignumPointer(BignumPointer&& other) noexcept
     : bn_(other.release()) {}
 
-BignumPointer BignumPointer::New() { return BignumPointer(BN_new()); }
+BignumPointer BignumPointer::New() {
+  return BignumPointer(BN_new());
+}
 
 BignumPointer BignumPointer::NewSecure() {
 #ifdef OPENSSL_IS_BORINGSSL
@@ -234,15 +248,21 @@ BignumPointer& BignumPointer::operator=(BignumPointer&& other) noexcept {
   return *new (this) BignumPointer(std::move(other));
 }
 
-BignumPointer::~BignumPointer() { reset(); }
+BignumPointer::~BignumPointer() {
+  reset();
+}
 
-void BignumPointer::reset(BIGNUM* bn) { bn_.reset(bn); }
+void BignumPointer::reset(BIGNUM* bn) {
+  bn_.reset(bn);
+}
 
 void BignumPointer::reset(const unsigned char* data, size_t len) {
   reset(BN_bin2bn(data, len, nullptr));
 }
 
-BIGNUM* BignumPointer::release() { return bn_.release(); }
+BIGNUM* BignumPointer::release() {
+  return bn_.release();
+}
 
 size_t BignumPointer::byteLength() const {
   if (!bn_) return 0;
@@ -297,7 +317,8 @@ DataPointer BignumPointer::EncodePadded(const BIGNUM* bn, size_t s) {
   BN_bn2binpad(bn, reinterpret_cast<unsigned char*>(buf.get()), size);
   return buf;
 }
-size_t BignumPointer::EncodePaddedInto(const BIGNUM* bn, unsigned char* out,
+size_t BignumPointer::EncodePaddedInto(const BIGNUM* bn,
+                                       unsigned char* out,
                                        size_t size) {
   if (bn == nullptr) return 0;
   return BN_bn2binpad(bn, out, size);
@@ -324,15 +345,25 @@ DataPointer BignumPointer::toHex() const {
   return DataPointer(hex, strlen(hex));
 }
 
-int BignumPointer::GetBitCount(const BIGNUM* bn) { return BN_num_bits(bn); }
+int BignumPointer::GetBitCount(const BIGNUM* bn) {
+  return BN_num_bits(bn);
+}
 
-int BignumPointer::GetByteCount(const BIGNUM* bn) { return BN_num_bytes(bn); }
+int BignumPointer::GetByteCount(const BIGNUM* bn) {
+  return BN_num_bytes(bn);
+}
 
-bool BignumPointer::isZero() const { return bn_ && BN_is_zero(bn_.get()); }
+bool BignumPointer::isZero() const {
+  return bn_ && BN_is_zero(bn_.get());
+}
 
-bool BignumPointer::isOne() const { return bn_ && BN_is_one(bn_.get()); }
+bool BignumPointer::isOne() const {
+  return bn_ && BN_is_one(bn_.get());
+}
 
-const BIGNUM* BignumPointer::One() { return BN_value_one(); }
+const BIGNUM* BignumPointer::One() {
+  return BN_value_one();
+}
 
 BignumPointer BignumPointer::clone() {
   if (!bn_) return {};
@@ -395,8 +426,12 @@ bool BignumPointer::generate(const PrimeConfig& params,
         },
         &innerCb);
   }
-  if (BN_generate_prime_ex(get(), params.bits, params.safe ? 1 : 0,
-                           params.add.get(), params.rem.get(), cb.get()) == 0) {
+  if (BN_generate_prime_ex(get(),
+                           params.bits,
+                           params.safe ? 1 : 0,
+                           params.add.get(),
+                           params.rem.get(),
+                           cb.get()) == 0) {
     return false;
   }
 
@@ -461,7 +496,9 @@ bool CSPRNG(void* buffer, size_t length) {
   return false;
 }
 
-int NoPasswordCallback(char* buf, int size, int rwflag, void* u) { return 0; }
+int NoPasswordCallback(char* buf, int size, int rwflag, void* u) {
+  return 0;
+}
 
 int PasswordCallback(char* buf, int size, int rwflag, void* u) {
   auto passphrase = static_cast<const Buffer<char>*>(u);
@@ -660,7 +697,9 @@ bool IsSafeAltName(const char* name, size_t length, AltNameOption option) {
   return true;
 }
 
-void PrintAltName(const BIOPointer& out, const char* name, size_t length,
+void PrintAltName(const BIOPointer& out,
+                  const char* name,
+                  size_t length,
                   AltNameOption option = AltNameOption::NONE,
                   const char* safe_prefix = nullptr) {
   if (IsSafeAltName(name, length, option)) {
@@ -743,15 +782,19 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
     BIO_printf(out.get(), "DirName:");
     BIOPointer tmp(BIO_new(BIO_s_mem()));
     NCRYPTO_ASSERT_TRUE(tmp);
-    if (X509_NAME_print_ex(tmp.get(), gen->d.dirn, 0,
-                           kX509NameFlagsRFC2253WithinUtf8JSON) < 0) {
+    if (X509_NAME_print_ex(
+            tmp.get(), gen->d.dirn, 0, kX509NameFlagsRFC2253WithinUtf8JSON) <
+        0) {
       return false;
     }
     char* oline = nullptr;
     long n_bytes = BIO_get_mem_data(tmp.get(), &oline);  // NOLINT(runtime/int)
     NCRYPTO_ASSERT_TRUE(n_bytes >= 0);
-    PrintAltName(out, oline, static_cast<size_t>(n_bytes),
-                 ncrypto::AltNameOption::UTF8, nullptr);
+    PrintAltName(out,
+                 oline,
+                 static_cast<size_t>(n_bytes),
+                 ncrypto::AltNameOption::UTF8,
+                 nullptr);
   } else if (gen->type == GEN_IPADD) {
     BIO_printf(out.get(), "IP Address:");
     const ASN1_OCTET_STRING* ip = gen->d.ip;
@@ -814,12 +857,18 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
       BIO_printf(out.get(), "othername:");
       if (unicode) {
         auto name = gen->d.otherName->value->value.utf8string;
-        PrintAltName(out, reinterpret_cast<const char*>(name->data),
-                     name->length, AltNameOption::UTF8, prefix);
+        PrintAltName(out,
+                     reinterpret_cast<const char*>(name->data),
+                     name->length,
+                     AltNameOption::UTF8,
+                     prefix);
       } else {
         auto name = gen->d.otherName->value->value.ia5string;
-        PrintAltName(out, reinterpret_cast<const char*>(name->data),
-                     name->length, AltNameOption::NONE, prefix);
+        PrintAltName(out,
+                     reinterpret_cast<const char*>(name->data),
+                     name->length,
+                     AltNameOption::NONE,
+                     prefix);
       }
     }
   } else if (gen->type == GEN_X400) {
@@ -906,13 +955,21 @@ X509Pointer& X509Pointer::operator=(X509Pointer&& other) noexcept {
   return *new (this) X509Pointer(std::move(other));
 }
 
-X509Pointer::~X509Pointer() { reset(); }
+X509Pointer::~X509Pointer() {
+  reset();
+}
 
-void X509Pointer::reset(X509* x509) { cert_.reset(x509); }
+void X509Pointer::reset(X509* x509) {
+  cert_.reset(x509);
+}
 
-X509* X509Pointer::release() { return cert_.release(); }
+X509* X509Pointer::release() {
+  return cert_.release();
+}
 
-X509View X509Pointer::view() const { return X509View(cert_.get()); }
+X509View X509Pointer::view() const {
+  return X509View(cert_.get());
+}
 
 BIOPointer X509View::toPEM() const {
   ClearErrorOnReturn clearErrorOnReturn;
@@ -949,7 +1006,9 @@ BIOPointer X509View::getSubject() const {
   if (cert_ == nullptr) return {};
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!bio) return {};
-  if (X509_NAME_print_ex(bio.get(), X509_get_subject_name(cert_), 0,
+  if (X509_NAME_print_ex(bio.get(),
+                         X509_get_subject_name(cert_),
+                         0,
                          kX509NameFlagsMultiline) <= 0) {
     return {};
   }
@@ -974,8 +1033,9 @@ BIOPointer X509View::getIssuer() const {
   if (cert_ == nullptr) return {};
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!bio) return {};
-  if (X509_NAME_print_ex(bio.get(), X509_get_issuer_name(cert_), 0,
-                         kX509NameFlagsMultiline) <= 0) {
+  if (X509_NAME_print_ex(
+          bio.get(), X509_get_issuer_name(cert_), 0, kX509NameFlagsMultiline) <=
+      0) {
     return {};
   }
   return bio;
@@ -1104,13 +1164,14 @@ bool X509View::checkPublicKey(const EVPKeyPointer& pkey) const {
   return X509_verify(const_cast<X509*>(cert_), pkey.get()) == 1;
 }
 
-X509View::CheckMatch X509View::checkHost(const std::string_view host, int flags,
+X509View::CheckMatch X509View::checkHost(const std::string_view host,
+                                         int flags,
                                          DataPointer* peerName) const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return CheckMatch::NO_MATCH;
   char* peername;
-  switch (X509_check_host(const_cast<X509*>(cert_), host.data(), host.size(),
-                          flags, &peername)) {
+  switch (X509_check_host(
+      const_cast<X509*>(cert_), host.data(), host.size(), flags, &peername)) {
     case 0:
       return CheckMatch::NO_MATCH;
     case 1: {
@@ -1131,8 +1192,8 @@ X509View::CheckMatch X509View::checkEmail(const std::string_view email,
                                           int flags) const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return CheckMatch::NO_MATCH;
-  switch (X509_check_email(const_cast<X509*>(cert_), email.data(), email.size(),
-                           flags)) {
+  switch (X509_check_email(
+      const_cast<X509*>(cert_), email.data(), email.size(), flags)) {
     case 0:
       return CheckMatch::NO_MATCH;
     case 1:
@@ -1300,8 +1361,8 @@ X509Pointer X509Pointer::PeerFrom(const SSLPointer& ssl) {
 // documentation. See the "OpenSSL Error Codes" section of doc/api/errors.md
 // Also *please* update the respective section in doc/api/tls.md as well
 std::string_view X509Pointer::ErrorCode(int32_t err) {  // NOLINT(runtime/int)
-#define CASE(CODE)        \
-  case X509_V_ERR_##CODE: \
+#define CASE(CODE)                                                             \
+  case X509_V_ERR_##CODE:                                                      \
     return #CODE;
   switch (err) {
     CASE(UNABLE_TO_GET_ISSUER_CERT)
@@ -1355,18 +1416,26 @@ BIOPointer& BIOPointer::operator=(BIOPointer&& other) noexcept {
   return *new (this) BIOPointer(std::move(other));
 }
 
-BIOPointer::~BIOPointer() { reset(); }
+BIOPointer::~BIOPointer() {
+  reset();
+}
 
-void BIOPointer::reset(BIO* bio) { bio_.reset(bio); }
+void BIOPointer::reset(BIO* bio) {
+  bio_.reset(bio);
+}
 
-BIO* BIOPointer::release() { return bio_.release(); }
+BIO* BIOPointer::release() {
+  return bio_.release();
+}
 
 bool BIOPointer::resetBio() const {
   if (!bio_) return 0;
   return BIO_reset(bio_.get()) == 1;
 }
 
-BIOPointer BIOPointer::NewMem() { return BIOPointer(BIO_new(BIO_s_mem())); }
+BIOPointer BIOPointer::NewMem() {
+  return BIOPointer(BIO_new(BIO_s_mem()));
+}
 
 BIOPointer BIOPointer::NewSecMem() {
 #ifdef OPENSSL_IS_BORINGSSL
@@ -1427,15 +1496,21 @@ DHPointer& DHPointer::operator=(DHPointer&& other) noexcept {
   return *new (this) DHPointer(std::move(other));
 }
 
-DHPointer::~DHPointer() { reset(); }
+DHPointer::~DHPointer() {
+  reset();
+}
 
-void DHPointer::reset(DH* dh) { dh_.reset(dh); }
+void DHPointer::reset(DH* dh) {
+  dh_.reset(dh);
+}
 
-DH* DHPointer::release() { return dh_.release(); }
+DH* DHPointer::release() {
+  return dh_.release();
+}
 
 BignumPointer DHPointer::FindGroup(const std::string_view name,
                                    FindGroupOption option) {
-#define V(n, p) \
+#define V(n, p)                                                                \
   if (EqualNoCase(name, n)) return BignumPointer(p(nullptr));
   if (option != FindGroupOption::NO_SMALL_PRIMES) {
 #ifndef OPENSSL_IS_BORINGSSL
@@ -1645,8 +1720,8 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
   if (out_size == 0) return {};
 
   auto out = DataPointer::Alloc(out_size);
-  if (EVP_PKEY_derive(ctx.get(), reinterpret_cast<uint8_t*>(out.get()),
-                      &out_size) <= 0) {
+  if (EVP_PKEY_derive(
+          ctx.get(), reinterpret_cast<uint8_t*>(out.get()), &out_size) <= 0) {
     return {};
   }
 
@@ -1686,9 +1761,11 @@ bool checkHkdfLength(const EVP_MD* md, size_t length) {
   return true;
 }
 
-bool hkdfInfo(const EVP_MD* md, const Buffer<const unsigned char>& key,
+bool hkdfInfo(const EVP_MD* md,
+              const Buffer<const unsigned char>& key,
               const Buffer<const unsigned char>& info,
-              const Buffer<const unsigned char>& salt, size_t length,
+              const Buffer<const unsigned char>& salt,
+              size_t length,
               Buffer<unsigned char>* out) {
   ClearErrorOnReturn clearErrorOnReturn;
 
@@ -1722,13 +1799,18 @@ bool hkdfInfo(const EVP_MD* md, const Buffer<const unsigned char>& key,
   unsigned char pseudorandom_key[EVP_MAX_MD_SIZE];
   unsigned pseudorandom_key_len = sizeof(pseudorandom_key);
 
-  if (HMAC(md, actual_salt.data(), actual_salt.size(), key.data, key.len,
-           pseudorandom_key, &pseudorandom_key_len) == nullptr) {
+  if (HMAC(md,
+           actual_salt.data(),
+           actual_salt.size(),
+           key.data,
+           key.len,
+           pseudorandom_key,
+           &pseudorandom_key_len) == nullptr) {
     return false;
   }
   if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
-      !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), pseudorandom_key,
-                                  pseudorandom_key_len)) {
+      !EVP_PKEY_CTX_set1_hkdf_key(
+          ctx.get(), pseudorandom_key, pseudorandom_key_len)) {
     return false;
   }
 
@@ -1736,14 +1818,23 @@ bool hkdfInfo(const EVP_MD* md, const Buffer<const unsigned char>& key,
 
   return EVP_PKEY_derive(ctx.get(), out->data, &length) > 0;
 #else
-  return HKDF(out->data, length, md, key.data, key.len, salt.data, salt.len,
-              info.data, info.len);
+  return HKDF(out->data,
+              length,
+              md,
+              key.data,
+              key.len,
+              salt.data,
+              salt.len,
+              info.data,
+              info.len);
 #endif
 }
 
-DataPointer hkdf(const EVP_MD* md, const Buffer<const unsigned char>& key,
+DataPointer hkdf(const EVP_MD* md,
+                 const Buffer<const unsigned char>& key,
                  const Buffer<const unsigned char>& info,
-                 const Buffer<const unsigned char>& salt, size_t length) {
+                 const Buffer<const unsigned char>& salt,
+                 size_t length) {
   auto buf = DataPointer::Alloc(length);
   if (!buf) return {};
   Buffer<unsigned char> out = buf;
@@ -1758,8 +1849,12 @@ bool checkScryptParams(uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem) {
 }
 
 bool scryptInto(const Buffer<const char>& pass,
-                const Buffer<const unsigned char>& salt, uint64_t N, uint64_t r,
-                uint64_t p, uint64_t maxmem, size_t length,
+                const Buffer<const unsigned char>& salt,
+                uint64_t N,
+                uint64_t r,
+                uint64_t p,
+                uint64_t maxmem,
+                size_t length,
                 Buffer<unsigned char>* out) {
   ClearErrorOnReturn clearErrorOnReturn;
 
@@ -1768,16 +1863,28 @@ bool scryptInto(const Buffer<const char>& pass,
   }
 
   if (auto dp = DataPointer::Alloc(length)) {
-    return EVP_PBE_scrypt(pass.data, pass.len, salt.data, salt.len, N, r, p,
-                          maxmem, out->data, length);
+    return EVP_PBE_scrypt(pass.data,
+                          pass.len,
+                          salt.data,
+                          salt.len,
+                          N,
+                          r,
+                          p,
+                          maxmem,
+                          out->data,
+                          length);
   }
 
   return false;
 }
 
 DataPointer scrypt(const Buffer<const char>& pass,
-                   const Buffer<const unsigned char>& salt, uint64_t N,
-                   uint64_t r, uint64_t p, uint64_t maxmem, size_t length) {
+                   const Buffer<const unsigned char>& salt,
+                   uint64_t N,
+                   uint64_t r,
+                   uint64_t p,
+                   uint64_t maxmem,
+                   size_t length) {
   if (auto dp = DataPointer::Alloc(length)) {
     Buffer<unsigned char> buf = dp;
     if (scryptInto(pass, salt, N, r, p, maxmem, length, &buf)) {
@@ -1788,9 +1895,12 @@ DataPointer scrypt(const Buffer<const char>& pass,
   return {};
 }
 
-bool pbkdf2Into(const EVP_MD* md, const Buffer<const char>& pass,
-                const Buffer<const unsigned char>& salt, uint32_t iterations,
-                size_t length, Buffer<unsigned char>* out) {
+bool pbkdf2Into(const EVP_MD* md,
+                const Buffer<const char>& pass,
+                const Buffer<const unsigned char>& salt,
+                uint32_t iterations,
+                size_t length,
+                Buffer<unsigned char>* out) {
   ClearErrorOnReturn clearErrorOnReturn;
 
   if (pass.len > INT_MAX || salt.len > INT_MAX || length > INT_MAX ||
@@ -1798,16 +1908,24 @@ bool pbkdf2Into(const EVP_MD* md, const Buffer<const char>& pass,
     return false;
   }
 
-  if (PKCS5_PBKDF2_HMAC(pass.data, pass.len, salt.data, salt.len, iterations,
-                        md, length, out->data)) {
+  if (PKCS5_PBKDF2_HMAC(pass.data,
+                        pass.len,
+                        salt.data,
+                        salt.len,
+                        iterations,
+                        md,
+                        length,
+                        out->data)) {
     return true;
   }
 
   return false;
 }
 
-DataPointer pbkdf2(const EVP_MD* md, const Buffer<const char>& pass,
-                   const Buffer<const unsigned char>& salt, uint32_t iterations,
+DataPointer pbkdf2(const EVP_MD* md,
+                   const Buffer<const char>& pass,
+                   const Buffer<const unsigned char>& salt,
+                   uint32_t iterations,
                    size_t length) {
   if (auto dp = DataPointer::Alloc(length)) {
     Buffer<unsigned char> buf = dp;
@@ -1823,8 +1941,8 @@ DataPointer pbkdf2(const EVP_MD* md, const Buffer<const char>& pass,
 
 EVPKeyPointer::PrivateKeyEncodingConfig::PrivateKeyEncodingConfig(
     const PrivateKeyEncodingConfig& other)
-    : PrivateKeyEncodingConfig(other.output_key_object, other.format,
-                               other.type) {
+    : PrivateKeyEncodingConfig(
+          other.output_key_object, other.format, other.type) {
   cipher = other.cipher;
   if (other.passphrase.has_value()) {
     auto& otherPassphrase = other.passphrase.value();
@@ -1846,7 +1964,9 @@ EVPKeyPointer::PrivateKeyEncodingConfig::operator=(
   return *new (this) PrivateKeyEncodingConfig(other);
 }
 
-EVPKeyPointer EVPKeyPointer::New() { return EVPKeyPointer(EVP_PKEY_new()); }
+EVPKeyPointer EVPKeyPointer::New() {
+  return EVPKeyPointer(EVP_PKEY_new());
+}
 
 EVPKeyPointer EVPKeyPointer::NewRawPublic(
     int id, const Buffer<const unsigned char>& data) {
@@ -1905,11 +2025,17 @@ EVPKeyPointer& EVPKeyPointer::operator=(EVPKeyPointer&& other) noexcept {
   return *new (this) EVPKeyPointer(std::move(other));
 }
 
-EVPKeyPointer::~EVPKeyPointer() { reset(); }
+EVPKeyPointer::~EVPKeyPointer() {
+  reset();
+}
 
-void EVPKeyPointer::reset(EVP_PKEY* pkey) { pkey_.reset(pkey); }
+void EVPKeyPointer::reset(EVP_PKEY* pkey) {
+  pkey_.reset(pkey);
+}
 
-EVP_PKEY* EVPKeyPointer::release() { return pkey_.release(); }
+EVP_PKEY* EVPKeyPointer::release() {
+  return pkey_.release();
+}
 
 int EVPKeyPointer::id(const EVP_PKEY* key) {
   if (key == nullptr) return 0;
@@ -1921,9 +2047,13 @@ int EVPKeyPointer::base_id(const EVP_PKEY* key) {
   return EVP_PKEY_base_id(key);
 }
 
-int EVPKeyPointer::id() const { return id(get()); }
+int EVPKeyPointer::id() const {
+  return id(get());
+}
 
-int EVPKeyPointer::base_id() const { return base_id(get()); }
+int EVPKeyPointer::base_id() const {
+  return base_id(get());
+}
 
 int EVPKeyPointer::bits() const {
   if (get() == nullptr) return 0;
@@ -2012,8 +2142,9 @@ EVPKeyPointer::ParseKeyResult TryParsePublicKeyInner(const BIOPointer& bp,
   // This skips surrounding data and decodes PEM to DER.
   {
     MarkPopErrorOnReturn mark_pop_error_on_return;
-    if (PEM_bytes_read_bio(&der_data, &der_len, nullptr, name, bp.get(),
-                           nullptr, nullptr) != 1)
+    if (PEM_bytes_read_bio(
+            &der_data, &der_len, nullptr, name, bp.get(), nullptr, nullptr) !=
+        1)
       return EVPKeyPointer::ParseKeyResult(
           EVPKeyPointer::PKParseError::NOT_RECOGNIZED);
   }
@@ -2027,8 +2158,10 @@ EVPKeyPointer::ParseKeyResult TryParsePublicKeyInner(const BIOPointer& bp,
   return EVPKeyPointer::ParseKeyResult(std::move(pkey));
 }
 
-constexpr bool IsASN1Sequence(const unsigned char* data, size_t size,
-                              size_t* data_offset, size_t* data_size) {
+constexpr bool IsASN1Sequence(const unsigned char* data,
+                              size_t size,
+                              size_t* data_offset,
+                              size_t* data_size) {
   if (size < 2 || data[0] != 0x30) return false;
 
   if (data[1] & 0x80) {
@@ -2083,7 +2216,8 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKeyPEM(
 
   // Try parsing as SubjectPublicKeyInfo (SPKI) first.
   if (auto ret = TryParsePublicKeyInner(
-          bp, "PUBLIC KEY",
+          bp,
+          "PUBLIC KEY",
           [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
             return d2i_PUBKEY(nullptr, p, l);
           })) {
@@ -2092,7 +2226,8 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKeyPEM(
 
   // Maybe it is PKCS#1.
   if (auto ret = TryParsePublicKeyInner(
-          bp, "RSA PUBLIC KEY",
+          bp,
+          "RSA PUBLIC KEY",
           [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
             return d2i_PublicKey(EVP_PKEY_RSA, nullptr, p, l);
           })) {
@@ -2101,7 +2236,8 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKeyPEM(
 
   // X.509 fallback.
   if (auto ret = TryParsePublicKeyInner(
-          bp, "CERTIFICATE",
+          bp,
+          "CERTIFICATE",
           [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
             X509Pointer x509(d2i_X509(nullptr, p, l));
             return x509 ? X509_get_pubkey(x509.get()) : nullptr;
@@ -2188,7 +2324,9 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePrivateKey(
 
   if (config.format == PKFormatType::PEM) {
     auto key = PEM_read_bio_PrivateKey(
-        bio.get(), nullptr, PasswordCallback,
+        bio.get(),
+        nullptr,
+        PasswordCallback,
         config.passphrase.has_value() ? &passphrase : nullptr);
     return keyOrError(EVPKeyPointer(key), config.passphrase.has_value());
   }
@@ -2205,7 +2343,9 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePrivateKey(
     case PKEncodingType::PKCS8: {
       if (IsEncryptedPrivateKeyInfo(buffer)) {
         auto key = d2i_PKCS8PrivateKey_bio(
-            bio.get(), nullptr, PasswordCallback,
+            bio.get(),
+            nullptr,
+            PasswordCallback,
             config.passphrase.has_value() ? &passphrase : nullptr);
         return keyOrError(EVPKeyPointer(key), config.passphrase.has_value());
       }
@@ -2251,9 +2391,13 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
       switch (config.format) {
         case PKFormatType::PEM: {
           err = PEM_write_bio_RSAPrivateKey(
-                    bio.get(), rsa, config.cipher,
+                    bio.get(),
+                    rsa,
+                    config.cipher,
                     reinterpret_cast<unsigned char*>(passphrase.data),
-                    passphrase.len, nullptr, nullptr) != 1;
+                    passphrase.len,
+                    nullptr,
+                    nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
@@ -2272,15 +2416,23 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
       switch (config.format) {
         case PKFormatType::PEM: {
           // Encode PKCS#8 as PEM.
-          err = PEM_write_bio_PKCS8PrivateKey(bio.get(), get(), config.cipher,
-                                              passphrase.data, passphrase.len,
-                                              nullptr, nullptr) != 1;
+          err = PEM_write_bio_PKCS8PrivateKey(bio.get(),
+                                              get(),
+                                              config.cipher,
+                                              passphrase.data,
+                                              passphrase.len,
+                                              nullptr,
+                                              nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
-          err = i2d_PKCS8PrivateKey_bio(bio.get(), get(), config.cipher,
-                                        passphrase.data, passphrase.len,
-                                        nullptr, nullptr) != 1;
+          err = i2d_PKCS8PrivateKey_bio(bio.get(),
+                                        get(),
+                                        config.cipher,
+                                        passphrase.data,
+                                        passphrase.len,
+                                        nullptr,
+                                        nullptr) != 1;
           break;
         }
         default: {
@@ -2299,9 +2451,13 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
       switch (config.format) {
         case PKFormatType::PEM: {
           err = PEM_write_bio_ECPrivateKey(
-                    bio.get(), ec, config.cipher,
+                    bio.get(),
+                    ec,
+                    config.cipher,
                     reinterpret_cast<unsigned char*>(passphrase.data),
-                    passphrase.len, nullptr, nullptr) != 1;
+                    passphrase.len,
+                    nullptr,
+                    nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
@@ -2487,11 +2643,17 @@ SSLPointer& SSLPointer::operator=(SSLPointer&& other) noexcept {
   return *new (this) SSLPointer(std::move(other));
 }
 
-SSLPointer::~SSLPointer() { reset(); }
+SSLPointer::~SSLPointer() {
+  reset();
+}
 
-void SSLPointer::reset(SSL* ssl) { ssl_.reset(ssl); }
+void SSLPointer::reset(SSL* ssl) {
+  ssl_.reset(ssl);
+}
 
-SSL* SSLPointer::release() { return ssl_.release(); }
+SSL* SSLPointer::release() {
+  return ssl_.release();
+}
 
 SSLPointer SSLPointer::New(const SSLCtxPointer& ctx) {
   if (!ctx) return {};
@@ -2508,8 +2670,10 @@ void SSLPointer::getCiphers(
   // and not have to explain their absence in the API docs. They are lower-cased
   // because the docs say they will be.
   static constexpr const char* TLS13_CIPHERS[] = {
-      "tls_aes_256_gcm_sha384", "tls_chacha20_poly1305_sha256",
-      "tls_aes_128_gcm_sha256", "tls_aes_128_ccm_8_sha256",
+      "tls_aes_256_gcm_sha384",
+      "tls_chacha20_poly1305_sha256",
+      "tls_aes_128_gcm_sha256",
+      "tls_aes_128_ccm_8_sha256",
       "tls_aes_128_ccm_sha256"};
 
   const int n = sk_SSL_CIPHER_num(ciphers);
@@ -2570,7 +2734,9 @@ const std::string_view SSLPointer::getClientHelloAlpn() const {
   size_t rem;
 
   if (!SSL_client_hello_get0_ext(
-          get(), TLSEXT_TYPE_application_layer_protocol_negotiation, &buf,
+          get(),
+          TLSEXT_TYPE_application_layer_protocol_negotiation,
+          &buf,
           &rem) ||
       rem < 2) {
     return {};
@@ -2637,7 +2803,9 @@ const SSL_CIPHER* SSLPointer::getCipher() const {
   return SSL_get_current_cipher(get());
 }
 
-bool SSLPointer::isServer() const { return SSL_is_server(get()) != 0; }
+bool SSLPointer::isServer() const {
+  return SSL_is_server(get()) != 0;
+}
 
 EVPKeyPointer SSLPointer::getPeerTempKey() const {
   if (!ssl_) return {};
@@ -2679,15 +2847,21 @@ SSLCtxPointer& SSLCtxPointer::operator=(SSLCtxPointer&& other) noexcept {
   return *new (this) SSLCtxPointer(std::move(other));
 }
 
-SSLCtxPointer::~SSLCtxPointer() { reset(); }
+SSLCtxPointer::~SSLCtxPointer() {
+  reset();
+}
 
-void SSLCtxPointer::reset(SSL_CTX* ctx) { ctx_.reset(ctx); }
+void SSLCtxPointer::reset(SSL_CTX* ctx) {
+  ctx_.reset(ctx);
+}
 
 void SSLCtxPointer::reset(const SSL_METHOD* method) {
   ctx_.reset(SSL_CTX_new(method));
 }
 
-SSL_CTX* SSLCtxPointer::release() { return ctx_.release(); }
+SSL_CTX* SSLCtxPointer::release() {
+  return ctx_.release();
+}
 
 SSLCtxPointer SSLCtxPointer::NewServer() {
   return SSLCtxPointer(SSL_CTX_new(TLS_server_method()));
@@ -2822,11 +2996,17 @@ CipherCtxPointer& CipherCtxPointer::operator=(
   return *new (this) CipherCtxPointer(std::move(other));
 }
 
-CipherCtxPointer::~CipherCtxPointer() { reset(); }
+CipherCtxPointer::~CipherCtxPointer() {
+  reset();
+}
 
-void CipherCtxPointer::reset(EVP_CIPHER_CTX* ctx) { ctx_.reset(ctx); }
+void CipherCtxPointer::reset(EVP_CIPHER_CTX* ctx) {
+  ctx_.reset(ctx);
+}
 
-EVP_CIPHER_CTX* CipherCtxPointer::release() { return ctx_.release(); }
+EVP_CIPHER_CTX* CipherCtxPointer::release() {
+  return ctx_.release();
+}
 
 void CipherCtxPointer::setFlags(int flags) {
   if (!ctx_) return;
@@ -2840,20 +3020,20 @@ bool CipherCtxPointer::setKeyLength(size_t length) {
 
 bool CipherCtxPointer::setIvLength(size_t length) {
   if (!ctx_) return false;
-  return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_IVLEN, length,
-                             nullptr);
+  return EVP_CIPHER_CTX_ctrl(
+      ctx_.get(), EVP_CTRL_AEAD_SET_IVLEN, length, nullptr);
 }
 
 bool CipherCtxPointer::setAeadTag(const Buffer<const char>& tag) {
   if (!ctx_) return false;
-  return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, tag.len,
-                             const_cast<char*>(tag.data));
+  return EVP_CIPHER_CTX_ctrl(
+      ctx_.get(), EVP_CTRL_AEAD_SET_TAG, tag.len, const_cast<char*>(tag.data));
 }
 
 bool CipherCtxPointer::setAeadTagLength(size_t length) {
   if (!ctx_) return false;
-  return EVP_CIPHER_CTX_ctrl(ctx_.get(), EVP_CTRL_AEAD_SET_TAG, length,
-                             nullptr);
+  return EVP_CIPHER_CTX_ctrl(
+      ctx_.get(), EVP_CTRL_AEAD_SET_TAG, length, nullptr);
 }
 
 bool CipherCtxPointer::setPadding(bool padding) {
@@ -2876,15 +3056,19 @@ int CipherCtxPointer::getNid() const {
   return EVP_CIPHER_CTX_nid(ctx_.get());
 }
 
-bool CipherCtxPointer::init(const Cipher& cipher, bool encrypt,
-                            const unsigned char* key, const unsigned char* iv) {
+bool CipherCtxPointer::init(const Cipher& cipher,
+                            bool encrypt,
+                            const unsigned char* key,
+                            const unsigned char* iv) {
   if (!ctx_) return false;
-  return EVP_CipherInit_ex(ctx_.get(), cipher, nullptr, key, iv,
-                           encrypt ? 1 : 0) == 1;
+  return EVP_CipherInit_ex(
+             ctx_.get(), cipher, nullptr, key, iv, encrypt ? 1 : 0) == 1;
 }
 
 bool CipherCtxPointer::update(const Buffer<const unsigned char>& in,
-                              unsigned char* out, int* out_len, bool finalize) {
+                              unsigned char* out,
+                              int* out_len,
+                              bool finalize) {
   if (!ctx_) return false;
   if (!finalize) {
     return EVP_CipherUpdate(ctx_.get(), out, out_len, in.data, in.len) == 1;
@@ -2920,7 +3104,9 @@ ECDSASigPointer& ECDSASigPointer::operator=(ECDSASigPointer&& other) noexcept {
   return *this;
 }
 
-ECDSASigPointer::~ECDSASigPointer() { reset(); }
+ECDSASigPointer::~ECDSASigPointer() {
+  reset();
+}
 
 void ECDSASigPointer::reset(ECDSA_SIG* sig) {
   sig_.reset();
@@ -2973,11 +3159,17 @@ ECGroupPointer& ECGroupPointer::operator=(ECGroupPointer&& other) noexcept {
   return *this;
 }
 
-ECGroupPointer::~ECGroupPointer() { reset(); }
+ECGroupPointer::~ECGroupPointer() {
+  reset();
+}
 
-void ECGroupPointer::reset(EC_GROUP* group) { group_.reset(); }
+void ECGroupPointer::reset(EC_GROUP* group) {
+  group_.reset();
+}
 
-EC_GROUP* ECGroupPointer::release() { return group_.release(); }
+EC_GROUP* ECGroupPointer::release() {
+  return group_.release();
+}
 
 ECGroupPointer ECGroupPointer::NewByCurveName(int nid) {
   return ECGroupPointer(EC_GROUP_new_by_curve_name(nid));
@@ -2997,11 +3189,17 @@ ECPointPointer& ECPointPointer::operator=(ECPointPointer&& other) noexcept {
   return *this;
 }
 
-ECPointPointer::~ECPointPointer() { reset(); }
+ECPointPointer::~ECPointPointer() {
+  reset();
+}
 
-void ECPointPointer::reset(EC_POINT* point) { point_.reset(point); }
+void ECPointPointer::reset(EC_POINT* point) {
+  point_.reset(point);
+}
 
-EC_POINT* ECPointPointer::release() { return point_.release(); }
+EC_POINT* ECPointPointer::release() {
+  return point_.release();
+}
 
 ECPointPointer ECPointPointer::New(const EC_GROUP* group) {
   return ECPointPointer(EC_POINT_new(group));
@@ -3010,8 +3208,8 @@ ECPointPointer ECPointPointer::New(const EC_GROUP* group) {
 bool ECPointPointer::setFromBuffer(const Buffer<const unsigned char>& buffer,
                                    const EC_GROUP* group) {
   if (!point_) return false;
-  return EC_POINT_oct2point(group, point_.get(), buffer.data, buffer.len,
-                            nullptr);
+  return EC_POINT_oct2point(
+      group, point_.get(), buffer.data, buffer.len, nullptr);
 }
 
 bool ECPointPointer::mul(const EC_GROUP* group, const BIGNUM* priv_key) {
@@ -3033,11 +3231,17 @@ ECKeyPointer& ECKeyPointer::operator=(ECKeyPointer&& other) noexcept {
   return *this;
 }
 
-ECKeyPointer::~ECKeyPointer() { reset(); }
+ECKeyPointer::~ECKeyPointer() {
+  reset();
+}
 
-void ECKeyPointer::reset(EC_KEY* key) { key_.reset(key); }
+void ECKeyPointer::reset(EC_KEY* key) {
+  key_.reset(key);
+}
 
-EC_KEY* ECKeyPointer::release() { return key_.release(); }
+EC_KEY* ECKeyPointer::release() {
+  return key_.release();
+}
 
 ECKeyPointer ECKeyPointer::clone() const {
   if (!key_) return {};
@@ -3057,8 +3261,8 @@ bool ECKeyPointer::setPublicKey(const ECPointPointer& pub) {
 bool ECKeyPointer::setPublicKeyRaw(const BignumPointer& x,
                                    const BignumPointer& y) {
   if (!key_) return false;
-  return EC_KEY_set_public_key_affine_coordinates(key_.get(), x.get(),
-                                                  y.get()) == 1;
+  return EC_KEY_set_public_key_affine_coordinates(
+             key_.get(), x.get(), y.get()) == 1;
 }
 
 bool ECKeyPointer::setPrivateKey(const BignumPointer& priv) {
@@ -3133,11 +3337,17 @@ EVPKeyCtxPointer& EVPKeyCtxPointer::operator=(
   return *this;
 }
 
-EVPKeyCtxPointer::~EVPKeyCtxPointer() { reset(); }
+EVPKeyCtxPointer::~EVPKeyCtxPointer() {
+  reset();
+}
 
-void EVPKeyCtxPointer::reset(EVP_PKEY_CTX* ctx) { ctx_.reset(ctx); }
+void EVPKeyCtxPointer::reset(EVP_PKEY_CTX* ctx) {
+  ctx_.reset(ctx);
+}
 
-EVP_PKEY_CTX* EVPKeyCtxPointer::release() { return ctx_.release(); }
+EVP_PKEY_CTX* EVPKeyCtxPointer::release() {
+  return ctx_.release();
+}
 
 EVPKeyCtxPointer EVPKeyCtxPointer::New(const EVPKeyPointer& key) {
   if (!key) return {};
@@ -3224,7 +3434,8 @@ bool EVPKeyCtxPointer::setRsaPadding(int padding) {
   return setRsaPadding(ctx_.get(), padding, std::nullopt);
 }
 
-bool EVPKeyCtxPointer::setRsaPadding(EVP_PKEY_CTX* ctx, int padding,
+bool EVPKeyCtxPointer::setRsaPadding(EVP_PKEY_CTX* ctx,
+                                     int padding,
                                      std::optional<int> salt_len) {
   if (ctx == nullptr) return false;
   if (EVP_PKEY_CTX_set_rsa_padding(ctx, padding) <= 0) {
@@ -3269,8 +3480,8 @@ bool EVPKeyCtxPointer::setRsaPssSaltlen(int salt_len) {
 bool EVPKeyCtxPointer::setRsaImplicitRejection() {
 #ifndef OPENSSL_IS_BORINGSSL
   if (!ctx_) return false;
-  return EVP_PKEY_CTX_ctrl_str(ctx_.get(), "rsa_pkcs1_implicit_rejection",
-                               "1") > 0;
+  return EVP_PKEY_CTX_ctrl_str(
+             ctx_.get(), "rsa_pkcs1_implicit_rejection", "1") > 0;
   // From the doc -2 means that the option is not supported.
   // The default for the option is enabled and if it has been
   // specifically disabled we want to respect that so we will
@@ -3319,8 +3530,8 @@ DataPointer EVPKeyCtxPointer::derive() const {
   if (EVP_PKEY_derive(ctx_.get(), nullptr, &len) != 1) return {};
   auto data = DataPointer::Alloc(len);
   if (!data) return {};
-  if (EVP_PKEY_derive(ctx_.get(), static_cast<unsigned char*>(data.get()),
-                      &len) != 1) {
+  if (EVP_PKEY_derive(
+          ctx_.get(), static_cast<unsigned char*>(data.get()), &len) != 1) {
     return {};
   }
   return data;
@@ -3377,8 +3588,11 @@ DataPointer EVPKeyCtxPointer::sign(const Buffer<const unsigned char>& data) {
   }
   auto buf = DataPointer::Alloc(len);
   if (!buf) return {};
-  if (EVP_PKEY_sign(ctx_.get(), static_cast<unsigned char*>(buf.get()), &len,
-                    data.data, data.len) != 1) {
+  if (EVP_PKEY_sign(ctx_.get(),
+                    static_cast<unsigned char*>(buf.get()),
+                    &len,
+                    data.data,
+                    data.len) != 1) {
     return {};
   }
   return buf.resize(len);
@@ -3400,8 +3614,10 @@ bool EVPKeyCtxPointer::signInto(const Buffer<const unsigned char>& data,
 namespace {
 
 using EVP_PKEY_cipher_init_t = int(EVP_PKEY_CTX* ctx);
-using EVP_PKEY_cipher_t = int(EVP_PKEY_CTX* ctx, unsigned char* out,
-                              size_t* outlen, const unsigned char* in,
+using EVP_PKEY_cipher_t = int(EVP_PKEY_CTX* ctx,
+                              unsigned char* out,
+                              size_t* outlen,
+                              const unsigned char* in,
                               size_t inlen);
 
 template <EVP_PKEY_cipher_init_t init, EVP_PKEY_cipher_t cipher>
@@ -3423,16 +3639,22 @@ DataPointer RSA_Cipher(const EVPKeyPointer& key,
   }
 
   size_t out_len = 0;
-  if (cipher(ctx.get(), nullptr, &out_len,
-             reinterpret_cast<const unsigned char*>(in.data), in.len) <= 0) {
+  if (cipher(ctx.get(),
+             nullptr,
+             &out_len,
+             reinterpret_cast<const unsigned char*>(in.data),
+             in.len) <= 0) {
     return {};
   }
 
   auto buf = DataPointer::Alloc(out_len);
   if (!buf) return {};
 
-  if (cipher(ctx.get(), static_cast<unsigned char*>(buf.get()), &out_len,
-             static_cast<const unsigned char*>(in.data), in.len) <= 0) {
+  if (cipher(ctx.get(),
+             static_cast<unsigned char*>(buf.get()),
+             &out_len,
+             static_cast<const unsigned char*>(in.data),
+             in.len) <= 0) {
     return {};
   }
 
@@ -3456,16 +3678,22 @@ DataPointer CipherImpl(const EVPKeyPointer& key,
   }
 
   size_t out_len = 0;
-  if (cipher(ctx.get(), nullptr, &out_len,
-             static_cast<const unsigned char*>(in.data), in.len) <= 0) {
+  if (cipher(ctx.get(),
+             nullptr,
+             &out_len,
+             static_cast<const unsigned char*>(in.data),
+             in.len) <= 0) {
     return {};
   }
 
   auto buf = DataPointer::Alloc(out_len);
   if (!buf) return {};
 
-  if (cipher(ctx.get(), static_cast<unsigned char*>(buf.get()), &out_len,
-             static_cast<const unsigned char*>(in.data), in.len) <= 0) {
+  if (cipher(ctx.get(),
+             static_cast<unsigned char*>(buf.get()),
+             &out_len,
+             static_cast<const unsigned char*>(in.data),
+             in.len) <= 0) {
     return {};
   }
 
@@ -3542,8 +3770,11 @@ bool Rsa::setPublicKey(BignumPointer&& n, BignumPointer&& e) {
   return false;
 }
 
-bool Rsa::setPrivateKey(BignumPointer&& d, BignumPointer&& q, BignumPointer&& p,
-                        BignumPointer&& dp, BignumPointer&& dq,
+bool Rsa::setPrivateKey(BignumPointer&& d,
+                        BignumPointer&& q,
+                        BignumPointer&& p,
+                        BignumPointer&& dp,
+                        BignumPointer&& dq,
                         BignumPointer&& qi) {
   if (!RSA_set0_key(const_cast<RSA*>(rsa_), nullptr, nullptr, d.get())) {
     return false;
@@ -3556,8 +3787,8 @@ bool Rsa::setPrivateKey(BignumPointer&& d, BignumPointer&& q, BignumPointer&& p,
   p.release();
   q.release();
 
-  if (!RSA_set0_crt_params(const_cast<RSA*>(rsa_), dp.get(), dq.get(),
-                           qi.get())) {
+  if (!RSA_set0_crt_params(
+          const_cast<RSA*>(rsa_), dp.get(), dq.get(), qi.get())) {
     return false;
   }
   dp.release();
@@ -3594,7 +3825,8 @@ DataPointer Cipher::decrypt(const EVPKeyPointer& key,
   return CipherImpl<EVP_PKEY_decrypt_init, EVP_PKEY_decrypt>(key, params, in);
 }
 
-DataPointer Cipher::sign(const EVPKeyPointer& key, const CipherParams& params,
+DataPointer Cipher::sign(const EVPKeyPointer& key,
+                         const CipherParams& params,
                          const Buffer<const void> in) {
   // private operation
   return CipherImpl<EVP_PKEY_sign_init, EVP_PKEY_sign>(key, params, in);
@@ -3616,24 +3848,34 @@ Ec::Ec(OSSL3_CONST EC_KEY* key)
     : ec_(key), x_(BignumPointer::New()), y_(BignumPointer::New()) {
   if (ec_ != nullptr) {
     MarkPopErrorOnReturn mark_pop_error_on_return;
-    EC_POINT_get_affine_coordinates(getGroup(), getPublicKey(), x_.get(),
-                                    y_.get(), nullptr);
+    EC_POINT_get_affine_coordinates(
+        getGroup(), getPublicKey(), x_.get(), y_.get(), nullptr);
   }
 }
 
-const EC_GROUP* Ec::getGroup() const { return ECKeyPointer::GetGroup(ec_); }
+const EC_GROUP* Ec::getGroup() const {
+  return ECKeyPointer::GetGroup(ec_);
+}
 
-int Ec::getCurve() const { return EC_GROUP_get_curve_name(getGroup()); }
+int Ec::getCurve() const {
+  return EC_GROUP_get_curve_name(getGroup());
+}
 
-uint32_t Ec::getDegree() const { return EC_GROUP_get_degree(getGroup()); }
+uint32_t Ec::getDegree() const {
+  return EC_GROUP_get_degree(getGroup());
+}
 
 std::string Ec::getCurveName() const {
   return std::string(OBJ_nid2sn(getCurve()));
 }
 
-const EC_POINT* Ec::getPublicKey() const { return EC_KEY_get0_public_key(ec_); }
+const EC_POINT* Ec::getPublicKey() const {
+  return EC_KEY_get0_public_key(ec_);
+}
 
-const BIGNUM* Ec::getPrivateKey() const { return EC_KEY_get0_private_key(ec_); }
+const BIGNUM* Ec::getPrivateKey() const {
+  return EC_KEY_get0_private_key(ec_);
+}
 
 // ============================================================================
 
@@ -3649,11 +3891,17 @@ EVPMDCtxPointer& EVPMDCtxPointer::operator=(EVPMDCtxPointer&& other) noexcept {
   return *this;
 }
 
-EVPMDCtxPointer::~EVPMDCtxPointer() { reset(); }
+EVPMDCtxPointer::~EVPMDCtxPointer() {
+  reset();
+}
 
-void EVPMDCtxPointer::reset(EVP_MD_CTX* ctx) { ctx_.reset(ctx); }
+void EVPMDCtxPointer::reset(EVP_MD_CTX* ctx) {
+  ctx_.reset(ctx);
+}
 
-EVP_MD_CTX* EVPMDCtxPointer::release() { return ctx_.release(); }
+EVP_MD_CTX* EVPMDCtxPointer::release() {
+  return ctx_.release();
+}
 
 bool EVPMDCtxPointer::digestInit(const EVP_MD* digest) {
   if (!ctx_) return false;
@@ -3749,8 +3997,11 @@ DataPointer EVPMDCtxPointer::signOneShot(
   if (!data) [[unlikely]]
     return {};
 
-  if (!EVP_DigestSign(ctx_.get(), static_cast<unsigned char*>(data.get()), &len,
-                      buf.data, buf.len)) {
+  if (!EVP_DigestSign(ctx_.get(),
+                      static_cast<unsigned char*>(data.get()),
+                      &len,
+                      buf.data,
+                      buf.len)) {
     return {};
   }
   return data;
@@ -3768,8 +4019,8 @@ DataPointer EVPMDCtxPointer::sign(
   auto data = DataPointer::Alloc(len);
   if (!data) [[unlikely]]
     return {};
-  if (!EVP_DigestSignFinal(ctx_.get(), static_cast<unsigned char*>(data.get()),
-                           &len)) {
+  if (!EVP_DigestSignFinal(
+          ctx_.get(), static_cast<unsigned char*>(data.get()), &len)) {
     return {};
   }
   return data.resize(len);
@@ -3788,7 +4039,8 @@ EVPMDCtxPointer EVPMDCtxPointer::New() {
 
 // ============================================================================
 
-bool extractP1363(const Buffer<const unsigned char>& buf, unsigned char* dest,
+bool extractP1363(const Buffer<const unsigned char>& buf,
+                  unsigned char* dest,
                   size_t n) {
   auto asn1_sig = ECDSASigPointer::Parse(buf);
   if (!asn1_sig) return false;
@@ -3811,11 +4063,17 @@ HMACCtxPointer& HMACCtxPointer::operator=(HMACCtxPointer&& other) noexcept {
   return *this;
 }
 
-HMACCtxPointer::~HMACCtxPointer() { reset(); }
+HMACCtxPointer::~HMACCtxPointer() {
+  reset();
+}
 
-void HMACCtxPointer::reset(HMAC_CTX* ctx) { ctx_.reset(ctx); }
+void HMACCtxPointer::reset(HMAC_CTX* ctx) {
+  ctx_.reset(ctx);
+}
 
-HMAC_CTX* HMACCtxPointer::release() { return ctx_.release(); }
+HMAC_CTX* HMACCtxPointer::release() {
+  return ctx_.release();
+}
 
 bool HMACCtxPointer::init(const Buffer<const void>& buf, const EVP_MD* md) {
   if (!ctx_) return false;
@@ -3824,7 +4082,8 @@ bool HMACCtxPointer::init(const Buffer<const void>& buf, const EVP_MD* md) {
 
 bool HMACCtxPointer::update(const Buffer<const void>& buf) {
   if (!ctx_) return false;
-  return HMAC_Update(ctx_.get(), static_cast<const unsigned char*>(buf.data),
+  return HMAC_Update(ctx_.get(),
+                     static_cast<const unsigned char*>(buf.data),
                      buf.len) == 1;
 }
 
@@ -3847,7 +4106,9 @@ bool HMACCtxPointer::digestInto(Buffer<void>* buf) {
   return true;
 }
 
-HMACCtxPointer HMACCtxPointer::New() { return HMACCtxPointer(HMAC_CTX_new()); }
+HMACCtxPointer HMACCtxPointer::New() {
+  return HMACCtxPointer(HMAC_CTX_new());
+}
 
 DataPointer hashDigest(const Buffer<const unsigned char>& buf,
                        const EVP_MD* md) {
@@ -3857,9 +4118,12 @@ DataPointer hashDigest(const Buffer<const unsigned char>& buf,
   auto data = DataPointer::Alloc(md_len);
   if (!data) return {};
 
-  if (!EVP_Digest(buf.data, buf.len,
-                  reinterpret_cast<unsigned char*>(data.get()), &result_size,
-                  md, nullptr)) {
+  if (!EVP_Digest(buf.data,
+                  buf.len,
+                  reinterpret_cast<unsigned char*>(data.get()),
+                  &result_size,
+                  md,
+                  nullptr)) {
     return {};
   }
 
@@ -3881,7 +4145,9 @@ X509Name::Iterator& X509Name::Iterator::operator++() {
   return *this;
 }
 
-X509Name::Iterator::operator bool() const { return loc_ < name_.total_; }
+X509Name::Iterator::operator bool() const {
+  return loc_ < name_.total_;
+}
 
 bool X509Name::Iterator::operator==(const Iterator& other) const {
   return loc_ == other.loc_;
@@ -3975,7 +4241,8 @@ extern "C" int bn_set_words(BIGNUM* bn, const BN_ULONG* words, size_t num);
 #error "Must define either OPENSSL_32_BIT or OPENSSL_64_BIT"
 #endif
 
-static BIGNUM* get_params(BIGNUM* ret, const BN_ULONG* words,
+static BIGNUM* get_params(BIGNUM* ret,
+                          const BN_ULONG* words,
                           size_t num_words) {
   BIGNUM* alloc = nullptr;
   if (ret == nullptr) {

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -2,4 +2,6 @@
 
 #include <gtest/gtest.h>
 
-TEST(basic, test_it) { SUCCEED(); }
+TEST(basic, test_it) {
+  SUCCEED();
+}


### PR DESCRIPTION
node and ncrypto are part of the same project, and should have the same code style. Doing the reformat now will avoid a lot of diff noise when I sync all the changes made in deps/ncrypto back to the ncrypto repo.