### PR TITLE
Bump boringssl to latest version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "ssl",
-    sha256 = "76962c003a298f405d1a5d273a74a94f58b69f65d64b8574a82d4c21c5e407be",
-    strip_prefix = "google-boringssl-6abe184",
+    sha256 = "64529449ef458381346b163302523a1fb876e5b667bec4a4bd38d0d2fff8b42b",
+    strip_prefix = "boringssl-0.20250818.0",
     type = "tgz",
-    urls = ["https://github.com/google/boringssl/tarball/6abe18402eb2a5e9b00158c6459646a948c53060"],
+    urls = ["https://github.com/google/boringssl/archive/refs/tags/0.20250818.0.tar.gz"],
 )


### PR DESCRIPTION
This version has already been tested by a consumer of ncrypto (workerd). See https://github.com/cloudflare/workerd/blob/006c957921e4b611e2c319b35ac28a4cd15b31f8/MODULE.bazel#L44.