### PR TITLE
fix: check ASN1_STRING_to_UTF8() failure

### DIFF
--- a/src/ncrypto.cpp
+++ b/src/ncrypto.cpp
@@ -4847,6 +4847,9 @@ std::pair<std::string, std::string> X509Name::Iterator::operator*() const {
 
   unsigned char* value_str;
   int value_str_size = ASN1_STRING_to_UTF8(&value_str, value);
+  if (value_str_size < 0) [[unlikely]] {
+    return {{}, {}};
+  }
 
   std::string out(reinterpret_cast<const char*>(value_str), value_str_size);
   OPENSSL_free(value_str);  // free after copy


### PR DESCRIPTION
This function returns a negative error code on error. When it does so, the `value_str` pointer will remain uninitialized and cause a crash later on when it is freed by OPENSSL_free(). Even if it wouldn't crash there, it still fails to signal the error and an empty string may be propagated to the callers.

Note: this was found by a static-dynamic analyser I'm developing.