### PR TITLE
fix: include climits to fix build

### DIFF
--- a/src/ncrypto.cpp
+++ b/src/ncrypto.cpp
@@ -22,6 +22,7 @@
 #endif
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cstring>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
Fixes the following build failure:
```
/home/nora/ncrypto/src/ncrypto.cpp: In function ‘bool ncrypto::CSPRNG(void*, size_t)’:
/home/nora/ncrypto/src/ncrypto.cpp:602:23: error: ‘INT_MAX’ was not declared in this scope
  602 |       while (length > INT_MAX && 1 == RAND_bytes(buf, INT_MAX)) {
      |                       ^~~~~~~
```

On `g++ (GCC) 16.1.1 20260728` on Linux